### PR TITLE
Added shift type for tutorial_orientation

### DIFF
--- a/src/domain/Shift.ts
+++ b/src/domain/Shift.ts
@@ -11,6 +11,7 @@ export enum ShiftType {
 	'Prat' = 'P',
 	'Lab' = 'L',
 	'Sem' = 'S',
+	'OT' = 'OT',
 }
 
 export const ShiftTypeFenix: Record<string, string> = {
@@ -20,6 +21,7 @@ export const ShiftTypeFenix: Record<string, string> = {
 	'P': 'PRACTICAL',
 	'L': 'LABORATORY',
 	'S': 'SEMINARY',
+	'OT': 'TUTORIAL_ORIENTATION'
 }
 
 /**


### PR DESCRIPTION
There appears to be a new shift type on Fenix. That shift type is present on `PLic` course on `LEIC-A`, this year, and is called `TUTORIAL_ORIENTATION` on the v2 API.

I think i added it correctly (works on my machine xD).